### PR TITLE
Con 306 suppression fix implement var setters

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -42,3 +42,8 @@ variables:
     required: true
     type: string
     default: "change"
+  AUDIT_AWS_IAM_OWNER_TAG:
+      description: "Enter an AWS tag whose value is an email address of the owner of the IAM object. (Optional)"
+      required: false
+      type: string
+      default: "NOT_A_TAG"

--- a/config.yaml
+++ b/config.yaml
@@ -42,8 +42,3 @@ variables:
     required: true
     type: string
     default: "change"
-  AUDIT_AWS_IAM_HTML_REPORT:
-      description: "Would you like to send a full IAM report? This is an email that details any violations found and includes a list of the violating cloud objects. Options - notify / nothing. Default is nothing."
-      required: true
-      type: string
-      default: "nothing"

--- a/services/config.rb
+++ b/services/config.rb
@@ -386,15 +386,36 @@ coreo_aws_rule "iam-root-access-key-2" do
   raise_when ["true"]
 end
 
+coreo_uni_util_variables "planwide" do
+  action :set
+  variables([
+                {'COMPOSITE::coreo_uni_util_variables.planwide.composite_name' => 'PLAN::stack_name'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.plan_name' => 'PLAN::name'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.results' => 'unset'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.number_violations' => 'unset'}
+            ])
+end
+
+
 coreo_aws_rule_runner_iam "advise-iam" do
   action :run
   rules ${AUDIT_AWS_IAM_ALERT_LIST}
 end
 
 
+coreo_uni_util_variables "update-planwide-1" do
+  action :set
+  variables([
+                {'COMPOSITE::coreo_uni_util_variables.planwide.results' => 'COMPOSITE::coreo_aws_rule_runner_iam.advise-iam.report'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.number_violations' => 'COMPOSITE::coreo_aws_rule_runner_iam.advise-iam.number_violations'},
+
+            ])
+end
+
 coreo_uni_util_jsrunner "tags-to-notifiers-array-iam" do
   action :run
   data_type "json"
+  provide_composite_access true
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
@@ -417,12 +438,19 @@ function setTableAndSuppression() {
   const fs = require('fs');
   const yaml = require('js-yaml');
   try {
-      table = yaml.safeLoad(fs.readFileSync('./table.yaml', 'utf8'));
       suppression = yaml.safeLoad(fs.readFileSync('./suppression.yaml', 'utf8'));
   } catch (e) {
+      console.log(`Error reading suppression.yaml file: ${e}`);
+      suppression = {};
+  }
+  try {
+      table = yaml.safeLoad(fs.readFileSync('./table.yaml', 'utf8'));
+  } catch (e) {
+      console.log(`Error reading table.yaml file: ${e}`);
+      table = {};
   }
   coreoExport('table', JSON.stringify(table));
-  coreoExport('suppression', JSON.stringify(table));
+  coreoExport('suppression', JSON.stringify(suppression));
   
   let alertListToJSON = "${AUDIT_AWS_IAM_ALERT_LIST}";
   let alertListArray = alertListToJSON.replace(/'/g, '"');

--- a/services/config.rb
+++ b/services/config.rb
@@ -482,14 +482,14 @@ end
 coreo_uni_util_variables "update-planwide-3" do
   action :set
   variables([
-                {'COMPOSITE::coreo_uni_util_variables.planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.iam-tags-to-notifiers-array.table'}
+                {'COMPOSITE::coreo_uni_util_variables.planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.table'}
             ])
 end
 
 coreo_uni_util_jsrunner "iam-tags-rollup" do
   action :run
   data_type "text"
-  json_input 'COMPOSITE::coreo_uni_util_jsrunner.iam-tags-to-notifiers-array.return'
+  json_input 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.return'
   function <<-EOH
 
 const notifiers = json_input;
@@ -520,7 +520,7 @@ end
 
 coreo_uni_util_notify "advise-iam-to-tag-values" do
   action((("${AUDIT_AWS_IAM_ALERT_RECIPIENT}".length > 0)) ? :notify : :nothing)
-  notifiers 'COMPOSITE::coreo_uni_util_jsrunner.iam-tags-to-notifiers-array.return'
+  notifiers 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.return'
 end
 
 coreo_uni_util_notify "advise-iam-rollup" do

--- a/services/config.rb
+++ b/services/config.rb
@@ -479,30 +479,62 @@ callback(notifiers);
   EOH
 end
 
-# coreo_uni_util_notify "advise-jsrunner-file-html-iam" do
-#   action :nothing
-#   type 'email'
-#   allow_empty true
-#   payload_type "text"
-#   payload 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.jsrunner_file'
-#   endpoint ({
-#       :to => '${AUDIT_AWS_IAM_ALERT_RECIPIENT}', :subject => 'jsrunner file for iam HTML'
-#   })
-# end
-
-# coreo_uni_util_notify "advise-package-html-iam" do
-#   action :nothing
-#   type 'email'
-#   allow_empty true
-#   payload_type "json"
-#   payload 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.packages_file'
-#   endpoint ({
-#       :to => '${AUDIT_AWS_IAM_ALERT_RECIPIENT}', :subject => 'package.json file for iam HTML'
-#   })
-# end
-
-coreo_uni_util_notify "advise-iam-html-report" do
-  action :${AUDIT_AWS_IAM_HTML_REPORT}
-  notifiers 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.return'
+coreo_uni_util_variables "update-planwide-3" do
+  action :set
+  variables([
+                {'COMPOSITE::coreo_uni_util_variables.planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.iam-tags-to-notifiers-array.table'}
+            ])
 end
 
+coreo_uni_util_jsrunner "iam-tags-rollup" do
+  action :run
+  data_type "text"
+  json_input 'COMPOSITE::coreo_uni_util_jsrunner.iam-tags-to-notifiers-array.return'
+  function <<-EOH
+
+const notifiers = json_input;
+
+function setTextRollup() {
+    let emailText = '';
+    let numberOfViolations = 0;
+    notifiers.forEach(notifier => {
+        const hasEmail = notifier['endpoint']['to'].length;
+        if(hasEmail) {
+            numberOfViolations += parseInt(notifier['num_violations']);
+            emailText += "recipient: " + notifier['endpoint']['to'] + " - " + "Violations: " + notifier['num_violations'] + "\\n";
+        }
+    });
+
+    textRollup += 'Number of Violating Cloud Objects: ' + numberOfViolations + "\\n";
+    textRollup += 'Rollup' + "\\n";
+    textRollup += emailText;
+}
+
+
+let textRollup = '';
+setTextRollup();
+
+callback(textRollup);
+  EOH
+end
+
+coreo_uni_util_notify "advise-iam-to-tag-values" do
+  action((("${AUDIT_AWS_IAM_ALERT_RECIPIENT}".length > 0)) ? :notify : :nothing)
+  notifiers 'COMPOSITE::coreo_uni_util_jsrunner.iam-tags-to-notifiers-array.return'
+end
+
+coreo_uni_util_notify "advise-iam-rollup" do
+  action((("${AUDIT_AWS_IAM_ALERT_RECIPIENT}".length > 0) and (! "${AUDIT_AWS_IAM_OWNER_TAG}".eql?("NOT_A_TAG"))) ? :notify : :nothing)
+  type 'email'
+  allow_empty ${AUDIT_AWS_IAM_ALLOW_EMPTY}
+  send_on '${AUDIT_AWS_IAM_SEND_ON}'
+  payload '
+composite name: PLAN::stack_name
+plan name: PLAN::name
+COMPOSITE::coreo_uni_util_jsrunner.iam-tags-rollup.return
+  '
+  payload_type 'text'
+  endpoint ({
+      :to => '${AUDIT_AWS_IAM_ALERT_RECIPIENT}', :subject => 'PLAN::stack_name New Rollup Report for PLAN::name plan from CloudCoreo'
+  })
+end


### PR DESCRIPTION
 CON-290 Cloudtrail jsrunner error if suppression.yaml file does not exist
 CON-303 must provide_composite_access to get to table and suppression yaml
 CON-304 remove action vars for audit notifiers
 CON-293 implement the var-setters and planwide changes across all audit stacks
 CON-294 decrement violation counts in the suppressions across audit stacks