### PR TITLE
Con 306 suppression fix implement var setters

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -474,6 +474,11 @@ const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG,
 
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
 const AuditIAM = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
+
+const JSONReportAfterGeneratingSuppression = AuditIAM.getJSONForAuditPanel();
+coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
+
+
 const notifiers = AuditIAM.getNotifiers();
 callback(notifiers);
   EOH
@@ -482,6 +487,7 @@ end
 coreo_uni_util_variables "update-planwide-3" do
   action :set
   variables([
+                {'COMPOSITE::coreo_uni_util_variables.planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.JSONReport'},
                 {'COMPOSITE::coreo_uni_util_variables.planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.table'}
             ])
 end


### PR DESCRIPTION
CON-290 Cloudtrail jsrunner error if suppression.yaml file does not exist
CON-303 must provide_composite_access to get to table and suppression yaml
CON-304 remove action vars for audit notifiers
CON-293 implement the var-setters and planwide changes across all audit stacks
CON-294 decrement violation counts in the suppressions across audit stacks