### PR TITLE
CON-390 Update all audit stack new version cloudcoreojsrunner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,12 @@ This repo is designed to work with CloudCoreo. It will monitor IAM against best 
   * description: Send reports always or only when there is a change? Options - always / change. Default is change.
   * default: change
 
-### `AUDIT_AWS_IAM_HTML_REPORT`:
-  * description: Would you like to send a full IAM report? This is an email that details any violations found and includes a list of the violating cloud objects. Options - notify / nothing. Default is nothing.
-  * default: nothing
-
 
 ## Optional variables with default
 
 ### `AUDIT_AWS_IAM_ALERT_LIST`:
-  * description: Which alerts would you like to check for? Default is all IAM alerts.
-  * default: iam-unusediamgroup, iam-multiple-keys, iam-inactive-key-no-rotation, iam-active-key-no-rotation, iam-passwordreuseprevention, iam-missing-password-policy, iam-expirepasswords, iam-no-mfa, iam-root-no-mfa, iam-root-active-key, iam-root-active-password, iam-user-attached-policies, iam-password-policy-uppercase, iam-password-policy-lowercase, iam-password-policy-symbol, iam-password-policy-number, iam-password-policy-min-length, iam-root-access-key-1, iam-root-access-key-2, iam-inventory-users, iam-inventory-roles, iam-inventory-groups, iam-inventory-policies
+  * description: Which alerts would you like to check for? Default is all IAM alerts. Choices are iam-unusediamgroup,iam-multiple-keys,iam-inactive-key-no-rotation,iam-active-key-no-rotation,iam-passwordreuseprevention,iam-missing-password-policy,iam-expirepasswords,iam-no-mfa,iam-root-no-mfa,iam-root-active-key,iam-root-active-password,iam-user-attached-policies,iam-password-policy-uppercase,iam-password-policy-lowercase,iam-password-policy-symbol,iam-password-policy-number,iam-password-policy-min-length,iam-root-access-key-1,iam-root-access-key-2,iam-inventory-users,iam-inventory-roles,iam-inventory-groups,iam-inventory-policies
+  * default: iam-unusediamgroup, iam-multiple-keys, iam-inactive-key-no-rotation, iam-active-key-no-rotation, iam-passwordreuseprevention, iam-missing-password-policy, iam-expirepasswords, iam-no-mfa, iam-root-no-mfa, iam-root-active-key, iam-root-active-password, iam-user-attached-policies, iam-password-policy-uppercase, iam-password-policy-lowercase, iam-password-policy-symbol, iam-password-policy-number, iam-password-policy-min-length, iam-root-access-key-1, iam-root-access-key-2
 
 
 ## Optional variables with no default

--- a/services/config.rb
+++ b/services/config.rb
@@ -461,7 +461,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-iam" do
   packages([
                {
                    :name => "cloudcoreo-jsrunner-commons",
-                   :version => "1.8.6"
+                   :version => "*"
                },
                {
                    :name => "js-yaml",
@@ -469,6 +469,7 @@ coreo_uni_util_jsrunner "tags-to-notifiers-array-iam" do
                }       ])
   json_input '{ "composite name":"PLAN::stack_name",
                 "plan name":"PLAN::name",
+                "cloud account name": "PLAN::cloud_account_name",
                 "violations": COMPOSITE::coreo_aws_rule_runner_iam.advise-iam.report}'
   function <<-EOH
   
@@ -511,18 +512,19 @@ const ALLOW_EMPTY = "${AUDIT_AWS_IAM_ALLOW_EMPTY}";
 const SEND_ON = "${AUDIT_AWS_IAM_SEND_ON}";
 const SHOWN_NOT_SORTED_VIOLATIONS_COUNTER = false;
 
-const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG,
+const SETTINGS = { NO_OWNER_EMAIL, OWNER_TAG,
      ALLOW_EMPTY, SEND_ON, SHOWN_NOT_SORTED_VIOLATIONS_COUNTER};
 
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
-const AuditIAM = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
+const AuditIAM = new CloudCoreoJSRunner(JSON_INPUT, SETTINGS);
 
-const JSONReportAfterGeneratingSuppression = AuditIAM.getSortedJSONForHTMLReports();
-coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
+const newJSONInput = AuditIAM.getSortedJSONForAuditPanel();
+coreoExport('JSONReport', JSON.stringify(newJSONInput));
+coreoExport('report', JSON.stringify(newJSONInput['violations']));
 
 
-const notifiers = AuditIAM.getNotifiers();
-callback(notifiers);
+const letters = AuditIAM.getLetters();
+callback(letters);
   EOH
 end
 
@@ -530,6 +532,7 @@ coreo_uni_util_variables "iam-update-planwide-3" do
   action :set
   variables([
                 {'COMPOSITE::coreo_uni_util_variables.iam-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.JSONReport'},
+                {'COMPOSITE::coreo_aws_rule_runner_iam.advise-iam.report' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.report'},
                 {'COMPOSITE::coreo_uni_util_variables.iam-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.table'}
             ])
 end

--- a/services/config.rb
+++ b/services/config.rb
@@ -386,13 +386,13 @@ coreo_aws_rule "iam-root-access-key-2" do
   raise_when ["true"]
 end
 
-coreo_uni_util_variables "planwide" do
+coreo_uni_util_variables "iam-planwide" do
   action :set
   variables([
-                {'COMPOSITE::coreo_uni_util_variables.planwide.composite_name' => 'PLAN::stack_name'},
-                {'COMPOSITE::coreo_uni_util_variables.planwide.plan_name' => 'PLAN::name'},
-                {'COMPOSITE::coreo_uni_util_variables.planwide.results' => 'unset'},
-                {'COMPOSITE::coreo_uni_util_variables.planwide.number_violations' => 'unset'}
+                {'COMPOSITE::coreo_uni_util_variables.iam-planwide.composite_name' => 'PLAN::stack_name'},
+                {'COMPOSITE::coreo_uni_util_variables.iam-planwide.plan_name' => 'PLAN::name'},
+                {'COMPOSITE::coreo_uni_util_variables.iam-planwide.results' => 'unset'},
+                {'COMPOSITE::coreo_uni_util_variables.iam-planwide.number_violations' => 'unset'}
             ])
 end
 
@@ -403,11 +403,11 @@ coreo_aws_rule_runner_iam "advise-iam" do
 end
 
 
-coreo_uni_util_variables "update-planwide-1" do
+coreo_uni_util_variables "iam-update-planwide-1" do
   action :set
   variables([
-                {'COMPOSITE::coreo_uni_util_variables.planwide.results' => 'COMPOSITE::coreo_aws_rule_runner_iam.advise-iam.report'},
-                {'COMPOSITE::coreo_uni_util_variables.planwide.number_violations' => 'COMPOSITE::coreo_aws_rule_runner_iam.advise-iam.number_violations'},
+                {'COMPOSITE::coreo_uni_util_variables.iam-planwide.results' => 'COMPOSITE::coreo_aws_rule_runner_iam.advise-iam.report'},
+                {'COMPOSITE::coreo_uni_util_variables.iam-planwide.number_violations' => 'COMPOSITE::coreo_aws_rule_runner_iam.advise-iam.number_violations'},
 
             ])
 end
@@ -484,11 +484,11 @@ callback(notifiers);
   EOH
 end
 
-coreo_uni_util_variables "update-planwide-3" do
+coreo_uni_util_variables "iam-update-planwide-3" do
   action :set
   variables([
-                {'COMPOSITE::coreo_uni_util_variables.planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.JSONReport'},
-                {'COMPOSITE::coreo_uni_util_variables.planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.table'}
+                {'COMPOSITE::coreo_uni_util_variables.iam-planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.JSONReport'},
+                {'COMPOSITE::coreo_uni_util_variables.iam-planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.tags-to-notifiers-array-iam.table'}
             ])
 end
 


### PR DESCRIPTION
PLA-3163 Engine does not support empty rules array
CON-287 Audit reports in WebUI and email don't list which AWS account being run on
CON-318 display meta_ attributes on cards
CON-334 add notifiers and jsrunner structures to the AWS config composite
CON-376 Report Emails: Update '# Resources' on cards to '# Cloud Objects'

Please note that this engine fix (https://bitbucket.org/cloudcoreo/engine/pull-requests/471) was merged only to master branch. If you run audit composites on the engine's dev branch it will give you the following error: "There's no rule named '' defined". So I guess we need to merge this fix to dev branch also. In master branch audit composites run correctly.