### PR TITLE
Adding query & triggers for user is admin

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -1135,6 +1135,27 @@ coreo_aws_rule "iam-user-is-admin" do
   operators [""]
   raise_when [true]
   id_map "static.no_op"
+  meta_rule_query <<~QUERY
+  {
+    users as var(func: <%= filter['user'] %>) { }
+    policies as var(func: <%= filter['policy'] %>) @cascade {
+      pname as policy_name
+    }
+    query(func: uid(users)) @cascade {
+      <%= default_predicates %>
+      user_name
+      relates_to @filter(uid(policies) AND eq(val(pname), "AdministratorAccess")) {
+        <%= default_predicates %>
+        policy_name
+        arn
+      }
+    }
+  }
+  QUERY
+  meta_rule_node_triggers({
+                              'user' => [],
+                              'policy' => ['policy_name']
+                          })
 end
 
 coreo_aws_rule "iam-instance-role-is-admin" do


### PR DESCRIPTION
This is only one way to know if a user is admin, and a bit naive at that. 

The other two known ways that we're not yet doing:
- User is part of a group that has the managed admin role (requires GSA bug fix)
- User has inline policies that grant admin permissions

It's also possible that a user can be in a group with an attached admin policy that isn't managed. Not sure if we want to try to encapsulate all that. For now, this is the direct rule of user with attached, managed admin policy.